### PR TITLE
adds basic framework for routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+
+const util = require('util');
+const path = require('path');
+
+const PORT = 8081;
+
+app.use(express.static('public'));
+
+app.get('/notes', (req, res) => {
+    res.render('notes')
+    res.send("Take some notes!")
+})
+
+app.get('/api/notes/:id', () => {
+    res.send('Here are your notes.')
+})
+
+app.post('/api/notes', (req, res) => {
+    res.send('Creating your notes.')
+})
+
+app.get('*', (req, res) => {
+    res.render('index')
+})
+
+app.listen(PORT, () => {
+    console.log(`Server listenting on Port: ${PORT}`)
+})


### PR DESCRIPTION
This PR defines the basic framework for the routes in a server.js file.  The outline for the basic GET and POST routes have been defined following the acceptance criteria.  The server is set to listen on port 8081.  Express is required and initialized in the server.js file.  The path module is also required to allow Express to work with the file system on the host and server content from locally hosted directories.  The basic GET routes for notes and the home page using the * selector have been defined.  The POST request route for /api/notes is also defined in the script.  A GET route to the same api/notes address has been defined with an id parameter.