### PR TITLE
destructured id parameter in get api/notes route

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,22 +9,22 @@ const PORT = 8081;
 app.use(express.static('public'));
 
 app.get('/notes', (req, res) => {
-    res.sendFile(path.join(__dirname, '/public/notes.html'))
-    // res.send("Take some notes!")
-})
+    res.sendFile(path.join(__dirname, '/public/notes.html'));
+});
 
-app.get('/api/notes/:id', () => {
+app.get('/api/notes/:id', (req, res) => {
+    const { id } = req.params;
     res.send('Here are your notes.')
-})
+});
 
 app.post('/api/notes', (req, res) => {
     res.send('Creating your notes.')
-})
+});
 
 app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, '/public/index.html'))
-})
+    res.sendFile(path.join(__dirname, '/public/index.html'));
+});
 
 app.listen(PORT, () => {
     console.log(`Server listenting on Port: ${PORT}`)
-})
+});


### PR DESCRIPTION
The id parameter in the api/notes route was destructured to make the data it returns available to the application. 