### PR TITLE
url encoded added to routes file

### DIFF
--- a/public/assets/routes/api.js
+++ b/public/assets/routes/api.js
@@ -8,6 +8,7 @@ const reading = util.promisify(fs.readFile);
 const writing = util.promisify(fs.writeFile);
 
 router.use(express.json());
+router.use(express.urlencoded({extended: true}));
 
 // The contents of the database are read from the file.
 // The database read is passed as the data to the .then and is parsed.


### PR DESCRIPTION
The apiroutes file needed the url encoded specified in order to correctly interpret and pare the requests being made from the application.  Deletes were not processing correctly without this.